### PR TITLE
dbt-semantic-interfaces 0.5.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/dbt_semantic_interfaces-{{ version }}.tar.gz
-  sha256: 3a497abef1ba8112affdf804b26bfdcd5468ed95cc924b509068e18d371c7c4d
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/dbt_semantic_interfaces-{{ version }}.tar.gz
+    sha256: 3a497abef1ba8112affdf804b26bfdcd5468ed95cc924b509068e18d371c7c4d
+  - url: https://github.com/dbt-labs/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: 91618c52e61731f0d51fd032aaffafc300087a752d596a0bd489a5e9bf94fc2a
+    folder: tests
 
 build:
   skip: true  # [py<38]
@@ -32,12 +35,17 @@ requirements:
     - typing-extensions >=4.4,<5
 
 test:
+  source_files:
+    - tests
   imports:
     - dbt_semantic_interfaces
   commands:
     - pip check
+    - pytest -vv tests
   requires:
     - pip
+    - pytest
+    - hypothesis
 
 about:
   home: https://github.com/dbt-labs/dbt-semantic-interfaces

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dbt-semantic-interfaces" %}
-{% set version = "0.4.1" %}
+{% set version = "0.5.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/dbt_semantic_interfaces-{{ version }}.tar.gz
-  sha256: d79cb4b5e5103099874530735a117db61f7dcbb1a774f9ce65068c24cb7e874e
+  sha256: 3a497abef1ba8112affdf804b26bfdcd5468ed95cc924b509068e18d371c7c4d
 
 build:
   skip: true  # [py<38]
@@ -21,15 +21,15 @@ requirements:
     - pip
   run:
     - python
-    - pydantic >=1.10,<2.dev0
-    - jsonschema >=4.0,<5.dev0
-    - pyyaml >=6.0,<7.dev0
+    - pydantic >=1.10,<3
+    - jsonschema >=4.0,<5
+    - pyyaml >=6.0,<7
     - more-itertools >=8.0,<11.0
-    - jinja2 >=3.0,<4.dev0
+    - jinja2 >=3.1.3,<4
     - click >=7.0,<9.0
-    - python-dateutil >=2.0,<3.dev0
-    - importlib-metadata >=6.0,<7.dev0
-    - typing-extensions >=4.4,<5.dev0
+    - python-dateutil >=2.0,<3
+    - importlib-metadata >=6.0,<7
+    - typing-extensions >=4.4,<5
 
 test:
   imports:


### PR DESCRIPTION
dbt-semantic-interfaces 0.5.1 

**Destination channel:** Defaults

### Links

- [PKG-6478]
- dev_url:        https://github.com/dbt-labs/dbt-semantic-interfaces/tree/v0.5.1
- conda_forge:    https://github.com/conda-forge/dbt-semantic-interfaces-feedstock
- pypi:           https://pypi.org/project/dbt-semantic-interfaces/0.5.1
- pypi inspector: https://inspector.pypi.io/project/dbt-semantic-interfaces/0.5.1

### Explanation of changes:

- new version number
- adding tests
- building 0.5.1 instead of newest version due to that `0.5.1` satisfies [dbt-core requirements](https://github.com/dbt-labs/dbt-core/blob/v1.8.9/core/setup.py#L76)


[PKG-6478]: https://anaconda.atlassian.net/browse/PKG-6478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ